### PR TITLE
FEAT: add prioritized scheduler

### DIFF
--- a/forms/executor/dfexecutor/formulasexecutor.py
+++ b/forms/executor/dfexecutor/formulasexecutor.py
@@ -43,17 +43,16 @@ def formulas_executor(physical_subtree: FunctionExecutionNode) -> DFTable:
                 # TODO: add support for axis_along_column
                 if axis == axis_along_row:
                     df = df.iloc[:, ref.col : ref.last_col + 1]
-                    # window_size = ref.last_row - ref.row + 1
-                    if out_ref_type == RefType.RR:
+                    if out_ref_type == RefType.RR and idx + ref.last_row + 1 <= len(df):
                         window = df.iloc[idx + ref.row : idx + ref.last_row + 1].to_numpy()
                     elif out_ref_type == RefType.FF:
                         window = df.iloc[ref.row : ref.last_row + 1].to_numpy()
-                    elif out_ref_type == RefType.FR:
+                    elif out_ref_type == RefType.FR and idx + ref.last_row + 1 <= len(df):
                         window = df.iloc[ref.row : idx + ref.last_row + 1].to_numpy()
-                    else:  # out_ref_type == RefType.RF
-                        window = df.iloc[ref.row + idx : ref.last_row + 1].values.to_numpy()
+                    elif out_ref_type == RefType.RF and ref.row + idx < ref.last_row + 1:
+                        window = df.iloc[ref.row + idx : ref.last_row + 1].to_numpy()
                 values.append(window)
-        res = func(*values)
+        res = np.nan if any(value is None for value in values) else func(*values)
         if isinstance(res, np.ndarray):
             if res.size != 1:
                 raise NonScalarNotSupportedException("A formula should only compute a scalar")

--- a/forms/executor/dfexecutor/planexecutor.py
+++ b/forms/executor/dfexecutor/planexecutor.py
@@ -35,7 +35,7 @@ def execute_one_subtree(physical_subtree: FunctionExecutionNode) -> pd.DataFrame
     for child in physical_subtree.children:
         if isinstance(child, FunctionExecutionNode):
             df_table = execute_one_subtree(child)
-            ref_node = create_intermediate_ref_node(df_table, child)
+            ref_node = create_intermediate_ref_node(DFTable(df=df_table), child)
             new_children.append(ref_node)
         else:
             new_children.append(child)

--- a/forms/scheduler/dfscheduler/dfscheduler.py
+++ b/forms/scheduler/dfscheduler/dfscheduler.py
@@ -11,25 +11,17 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+
 from forms.executor.compiler import BaseCompiler
-from forms.executor.executionnode import ExecutionNode, create_intermediate_ref_node
+from forms.executor.executionnode import (
+    ExecutionNode,
+    create_intermediate_ref_node,
+)
+from forms.scheduler.dfscheduler.phase import create_phase_by_name
 from forms.scheduler.scheduler import BaseScheduler
 from forms.executor.table import Table
 from forms.executor.dfexecutor.utils import remote_access_planning
 from forms.executor.utils import ExecutionConfig, ExecutionContext
-from forms.utils.treenode import link_parent_to_children
 
 
 class DFSimpleScheduler(BaseScheduler):
@@ -67,56 +59,34 @@ class DFSimpleScheduler(BaseScheduler):
         self.execution_tree = create_intermediate_ref_node(result_table, execution_subtree)
 
 
-class RFFRTwoPhaseScheduler(BaseScheduler):
+class PrioritizedScheduler(BaseScheduler):
     def __init__(
         self, compiler: BaseCompiler, exec_config: ExecutionConfig, execution_tree: ExecutionNode
     ):
         super().__init__(compiler, exec_config, execution_tree)
-        self.phase_one_scheduled = False
-        self.phase_two_scheduled = False
-        self.phase_one_finished = False
-        self.ref_type = execution_tree.children[0].children[0].out_ref_type
-        self.partition_plan = self.cost_model.get_partition_plan(
-            self.execution_tree, self.exec_config.cores
-        )
+        self.phases_name = ["ff", "rffrphaseone", "rffrphasetwo", "simple"]
+        self.idx = -1
+        self.next_phase()
+
+    def next_phase(self):
+        self.idx += 1
+        p_name = self.phases_name[self.idx]
+        phase = create_phase_by_name(p_name, self.compiler, self.exec_config, self.execution_tree)
+        self.curr_phase = phase
 
     def next_subtree(self) -> (ExecutionNode, list):
-        cores = self.exec_config.cores
-        partition_plan = self.partition_plan
-        exec_context_list = [
-            ExecutionContext(
-                partition_plan[i],
-                partition_plan[i + 1],
-                self.exec_config.axis,
-            )
-            for i in range(cores)
-        ]
-        if not self.phase_one_scheduled:
-            # create subtrees from child node (PHASEONE node) and slice table for each subtree
-            child = self.execution_tree.children[0]
-            exec_subtree_list = [child.gen_exec_subtree() for _ in range(cores)]
-            for i in range(cores):
-                exec_subtree_list[i].set_exec_context(exec_context_list[i])
-                exec_subtree_list[i].exec_context.set_all_formula_idx(partition_plan)
-            self.phase_one_scheduled = True
-            return self.execution_tree, exec_subtree_list
-        elif self.phase_one_finished and not self.phase_two_scheduled:
-            # create subtrees from PHASETWO node such that each tree has the whole PHASEONE result table
-            exec_subtree_list = [self.execution_tree.gen_exec_subtree() for _ in range(cores)]
-            for i in range(cores):
-                exec_subtree_list[i].set_exec_context(exec_context_list[i])
-                exec_subtree_list[i].exec_context.set_all_formula_idx(partition_plan)
-            self.phase_two_scheduled = True
-            return self.execution_tree, exec_subtree_list
+        while self.curr_phase.empty:
+            self.next_phase()
+        if self.idx < len(self.phases_name):
+            while not self.curr_phase.is_finished():
+                return self.curr_phase.next_subtree()
         return None, None
 
     def finish_subtree(self, execution_subtree: ExecutionNode, result_table: Table):
-        if not self.phase_one_finished:
-            # link PHASEONE result ref_node with self.execution_tree
-            self.phase_one_finished = True
-            ref_node = create_intermediate_ref_node(result_table, execution_subtree)
-            ref_node.out_ref_type = self.ref_type
-            children = [ref_node]
-            link_parent_to_children(self.execution_tree, children)
-        else:
-            self.execution_tree = create_intermediate_ref_node(result_table, execution_subtree)
+        self.curr_phase.finish_subtree(execution_subtree, result_table)
+        if self.curr_phase.is_finished():
+            if self.execution_tree != self.curr_phase.execution_tree:
+                # replace self.execution_tree if the root is already changed
+                self.execution_tree = self.curr_phase.execution_tree
+            elif self.idx < len(self.phases_name) - 1:
+                self.next_phase()

--- a/forms/scheduler/dfscheduler/phase.py
+++ b/forms/scheduler/dfscheduler/phase.py
@@ -1,0 +1,307 @@
+#  Copyright 2022-2023 The FormS Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from enum import Enum, auto
+
+from forms.core.config import forms_config
+from forms.executor.compiler import BaseCompiler
+from forms.executor.costmodel import create_cost_model_by_name
+from forms.executor.dfexecutor.utils import remote_access_planning
+from forms.executor.executionnode import (
+    ExecutionNode,
+    create_intermediate_ref_node,
+    FunctionExecutionNode,
+)
+from forms.executor.table import Table
+from forms.executor.utils import ExecutionConfig, ExecutionContext
+from forms.utils.exceptions import PhaseNotSupportedException
+from forms.utils.optimizations import FRRFOptimization
+from forms.utils.reference import RefType
+from forms.utils.treenode import link_parent_to_children
+
+
+class BasePhase:
+    def __init__(
+        self, compiler: BaseCompiler, exec_config: ExecutionConfig, execution_tree: ExecutionNode
+    ):
+        self.compiler = compiler
+        self.exec_config = exec_config
+        self.execution_tree = execution_tree
+        self.cost_model = create_cost_model_by_name(forms_config.cost_model, exec_config.num_of_formulae)
+        self.partition_plan = self.cost_model.get_partition_plan(
+            self.execution_tree, self.exec_config.cores
+        )
+        self.phase_scheduled = False
+        self.phase_finished = False
+
+    def next_subtree(self):
+        pass
+
+    def finish_subtree(self, execution_subtree: ExecutionNode, result_table: Table):
+        pass
+
+    def is_finished(self):
+        return self.phase_finished
+
+
+class SimplePhase(BasePhase):
+    def __init__(
+        self, compiler: BaseCompiler, exec_config: ExecutionConfig, execution_tree: ExecutionNode
+    ):
+        super().__init__(compiler, exec_config, execution_tree)
+        self.empty = False
+
+    def next_subtree(self):
+        if not self.phase_scheduled:
+            cores = self.exec_config.cores
+            partition_plan = self.partition_plan
+            exec_subtree_list = [self.execution_tree.gen_exec_subtree() for _ in range(cores)]
+            exec_context_list = [
+                ExecutionContext(
+                    partition_plan[i],
+                    partition_plan[i + 1],
+                    self.exec_config.axis,
+                )
+                for i in range(cores)
+            ]
+            for i in range(cores):
+                exec_subtree_list[i].set_exec_context(exec_context_list[i])
+                exec_subtree_list[i] = remote_access_planning(exec_subtree_list[i])
+            exec_subtree_list = [
+                self.compiler.compile(exec_subtree_list[i], self.exec_config.function_executor)
+                for i in range(cores)
+            ]
+            self.phase_scheduled = True
+            return self.execution_tree, exec_subtree_list
+        return None, None
+
+    def finish_subtree(self, execution_subtree: ExecutionNode, result_table: Table):
+        self.execution_tree = create_intermediate_ref_node(result_table, execution_subtree)
+        self.phase_finished = True
+
+
+class FFPhase(BasePhase):
+    def __init__(
+        self, compiler: BaseCompiler, exec_config: ExecutionConfig, execution_tree: ExecutionNode
+    ):
+        super().__init__(compiler, exec_config, execution_tree)
+        self.ff_trees = []
+        self.subtrees = []
+        self.find_ff_subtrees(self.execution_tree)
+        self.scheduled_idx = 0
+        self.finished_idx = 0
+        self.empty = len(self.ff_trees) == 0
+
+    def find_ff_subtrees(self, execution_tree):
+        if (
+            isinstance(execution_tree, FunctionExecutionNode)
+            and execution_tree.out_ref_type == RefType.FF
+        ):
+            self.subtrees.append(execution_tree.gen_exec_subtree())
+            self.ff_trees.append(execution_tree)
+        elif execution_tree.children:
+            for child in execution_tree.children:
+                self.find_ff_subtrees(child)
+
+    def next_subtree(self):
+        if not self.phase_scheduled:
+            curr_idx = self.scheduled_idx
+            subtree = self.subtrees[curr_idx]
+            subtree.set_exec_context(
+                ExecutionContext(
+                    0,
+                    self.exec_config.num_of_formulae,
+                    self.exec_config.axis,
+                )
+            )
+            self.scheduled_idx += 1
+            if self.scheduled_idx == len(self.ff_trees):
+                self.phase_scheduled = True
+            return self.ff_trees[curr_idx], [self.subtrees[curr_idx]]
+        return None, None
+
+    def finish_subtree(self, execution_subtree: ExecutionNode, result_table: Table):
+        ref_node = create_intermediate_ref_node(result_table, execution_subtree)
+        parent = execution_subtree.parent
+        if parent is not None:
+            children = []
+            for child in parent.children:
+                if execution_subtree == child:
+                    children.append(ref_node)
+                else:
+                    children.append(child)
+            link_parent_to_children(parent, children)
+        else:
+            self.execution_tree = create_intermediate_ref_node(result_table, execution_subtree)
+        self.finished_idx += 1
+        if self.finished_idx == len(self.ff_trees):
+            self.phase_finished = True
+
+
+class RFFRPhaseOne(BasePhase):
+    def __init__(self, compiler, exec_config, execution_tree):
+        super().__init__(compiler, exec_config, execution_tree)
+        self.subtrees = []
+        self.phaseone_trees = []
+        self.find_phase_one_subtrees(self.execution_tree)
+        self.idx = 0
+        self.empty = len(self.phaseone_trees) == 0
+
+    def find_phase_one_subtrees(self, execution_tree):
+        if (
+            isinstance(execution_tree, FunctionExecutionNode)
+            and execution_tree.fr_rf_optimization == FRRFOptimization.PHASEONE
+        ):
+            self.subtrees.append(execution_tree.gen_exec_subtree())
+            self.phaseone_trees.append(execution_tree)
+        elif execution_tree.children:
+            for child in execution_tree.children:
+                self.find_phase_one_subtrees(child)
+
+    def next_subtree(self):
+        if not self.phase_scheduled:
+            cores = self.exec_config.cores
+            partition_plan = self.partition_plan
+            exec_context_list = [
+                ExecutionContext(
+                    partition_plan[i],
+                    partition_plan[i + 1],
+                    self.exec_config.axis,
+                )
+                for i in range(cores)
+            ]
+            phase_one_tree = self.phaseone_trees[self.idx]
+            subtree = self.subtrees[self.idx]
+            exec_subtree_list = [subtree.gen_exec_subtree() for _ in range(cores)]
+            for i in range(cores):
+                exec_subtree_list[i].set_exec_context(exec_context_list[i])
+                exec_subtree_list[i].exec_context.set_all_formula_idx(partition_plan)
+                exec_subtree_list[i] = remote_access_planning(exec_subtree_list[i])
+            exec_subtree_list = [
+                self.compiler.compile(exec_subtree_list[i], self.exec_config.function_executor)
+                for i in range(cores)
+            ]
+            self.phase_scheduled = True
+            return phase_one_tree, exec_subtree_list
+        return None, None
+
+    def finish_subtree(self, execution_subtree: ExecutionNode, result_table: Table):
+        ref_node = create_intermediate_ref_node(result_table, execution_subtree)
+        ref_node.out_ref_type = self.phaseone_trees[self.idx].children[0].out_ref_type
+        parent = execution_subtree.parent
+        if parent is not None:
+            children = []
+            for child in parent.children:
+                if execution_subtree == child:
+                    children.append(ref_node)
+                else:
+                    children.append(child)
+            link_parent_to_children(parent, children)
+        self.idx += 1
+        if self.idx == len(self.phaseone_trees):
+            self.phase_finished = True
+        else:
+            self.phase_scheduled = False
+
+
+class RFFRPhaseTwo(BasePhase):
+    def __init__(
+        self, compiler: BaseCompiler, exec_config: ExecutionConfig, execution_tree: ExecutionNode
+    ):
+        super().__init__(compiler, exec_config, execution_tree)
+        self.subtrees = []
+        self.phasetwo_trees = []
+        self.find_phase_two_subtrees(self.execution_tree)
+        self.idx = 0
+        self.empty = len(self.phasetwo_trees) == 0
+
+    def find_phase_two_subtrees(self, execution_tree):
+        if (
+            isinstance(execution_tree, FunctionExecutionNode)
+            and execution_tree.fr_rf_optimization == FRRFOptimization.PHASETWO
+        ):
+            self.subtrees.append(execution_tree.gen_exec_subtree())
+            self.phasetwo_trees.append(execution_tree)
+        elif execution_tree.children:
+            for child in execution_tree.children:
+                self.find_phase_two_subtrees(child)
+
+    def next_subtree(self):
+        if not self.phase_scheduled:
+            cores = self.exec_config.cores
+            partition_plan = self.partition_plan
+            exec_context_list = [
+                ExecutionContext(
+                    partition_plan[i],
+                    partition_plan[i + 1],
+                    self.exec_config.axis,
+                )
+                for i in range(cores)
+            ]
+            phasetwo_tree = self.phasetwo_trees[self.idx]
+            subtree = self.subtrees[self.idx]
+            exec_subtree_list = [subtree.gen_exec_subtree() for _ in range(cores)]
+            for i in range(cores):
+                exec_subtree_list[i].set_exec_context(exec_context_list[i])
+                exec_subtree_list[i].exec_context.set_all_formula_idx(partition_plan)
+                exec_subtree_list[i] = remote_access_planning(exec_subtree_list[i])
+            exec_subtree_list = [
+                self.compiler.compile(exec_subtree_list[i], self.exec_config.function_executor)
+                for i in range(cores)
+            ]
+            self.phase_scheduled = True
+            return phasetwo_tree, exec_subtree_list
+        return None, None
+
+    def finish_subtree(self, execution_subtree: ExecutionNode, result_table: Table):
+        ref_node = create_intermediate_ref_node(result_table, execution_subtree)
+        parent = execution_subtree.parent
+        if parent is not None:
+            children = []
+            for child in parent.children:
+                if execution_subtree == child:
+                    children.append(ref_node)
+                else:
+                    children.append(child)
+            link_parent_to_children(parent, children)
+        else:
+            self.execution_tree = create_intermediate_ref_node(result_table, execution_subtree)
+        self.idx += 1
+        if self.idx == len(self.phasetwo_trees):
+            self.phase_finished = True
+        else:
+            self.phase_scheduled = False
+
+
+class Phases(Enum):
+    SIMPLE = auto()
+    FF = auto()
+    RFFRPhaseOne = auto()
+    RFFRPhaseTwo = auto()
+
+
+scheduler_class_dict = {
+    Phases.SIMPLE.name.lower(): SimplePhase,
+    Phases.FF.name.lower(): FFPhase,
+    Phases.RFFRPhaseOne.name.lower(): RFFRPhaseOne,
+    Phases.RFFRPhaseTwo.name.lower(): RFFRPhaseTwo,
+}
+
+
+def create_phase_by_name(
+    p_name: str, compiler: BaseCompiler, exec_config: ExecutionConfig, execution_tree: ExecutionNode
+):
+    if p_name.lower() in scheduler_class_dict.keys():
+        return scheduler_class_dict[p_name](compiler, exec_config, execution_tree)
+    raise PhaseNotSupportedException(f"Phase {p_name} is not supported")

--- a/forms/scheduler/utils.py
+++ b/forms/scheduler/utils.py
@@ -16,18 +16,18 @@ from enum import Enum, auto
 from forms.executor.compiler import BaseCompiler
 from forms.executor.executionnode import ExecutionNode
 from forms.executor.utils import ExecutionConfig
-from forms.scheduler.dfscheduler.dfscheduler import DFSimpleScheduler, RFFRTwoPhaseScheduler
+from forms.scheduler.dfscheduler.dfscheduler import DFSimpleScheduler, PrioritizedScheduler
 from forms.utils.exceptions import SchedulerNotSupportedException
 
 
 class Schedulers(Enum):
     SIMPLE = auto()
-    FRRFTWOPHASE = auto()
+    PRIORITIZED = auto()
 
 
 scheduler_class_dict = {
     Schedulers.SIMPLE.name.lower(): DFSimpleScheduler,
-    Schedulers.FRRFTWOPHASE.name.lower(): RFFRTwoPhaseScheduler,
+    Schedulers.PRIORITIZED.name.lower(): PrioritizedScheduler,
 }
 
 

--- a/forms/utils/exceptions.py
+++ b/forms/utils/exceptions.py
@@ -63,3 +63,7 @@ class CostModelNotSupportedException(FormSException):
 
 class NonScalarNotSupportedException(FormSException):
     """Exception raised for non-scalar output"""
+
+
+class PhaseNotSupportedException(FormSException):
+    """Exception raised for unsupported Phase"""

--- a/tests/test_compute_formula.py
+++ b/tests/test_compute_formula.py
@@ -45,6 +45,13 @@ def test_compute_sum():
     assert np.array_equal(computed_df.values, expected_df.values, equal_nan=True)
 
 
+def test_compute_sum_ff():
+    global df
+    computed_df = forms.compute_formula(df, "=SUM(A$1:B$3)")
+    expected_df = pd.DataFrame(np.full(100, 6.0))
+    assert np.array_equal(computed_df.values, expected_df.values)
+
+
 def test_compute_literal():
     global df
     computed_df = forms.compute_formula(df, "=SUM(A1:B3, 10)")

--- a/tests/test_execute_sum.py
+++ b/tests/test_execute_sum.py
@@ -60,7 +60,8 @@ def test_execute_sum_simple_formula_rr():
 # try to mock forms.compute_formula(df, "=SUM(A$1:B$3)")
 def test_execute_sum_simple_formula_ff():
     result = compute_one_formula(Ref(0, 0, 2, 1), RefType.FF)
-    real_result = pd.DataFrame(np.full(50, 6.0))
+    # according to current semantics, ff will only return one single value for all column
+    real_result = pd.DataFrame([6.0])
     assert np.array_equal(result.df.values, real_result.values)
 
 

--- a/tests/test_execute_sumif.py
+++ b/tests/test_execute_sumif.py
@@ -30,8 +30,15 @@ def execute_before_and_after_one_test():
     yield
 
 
-def test_compute_sum_if():
-    global df
+def test_compute_sum_if_ff():
     computed_df = forms.compute_formula(df, "=SUMIF(A$1:A$40, C1, B$1:B$40)")
     expected_df = pd.DataFrame(np.full(40, 10.0))
     assert np.array_equal(computed_df.values, expected_df.values)
+
+
+def test_compute_sum_if_rr():
+    global df
+    computed_df = forms.compute_formula(df, "=SUMIF(A1:A5, C1, B1:B5)")
+    expected_df = pd.DataFrame(np.full(40, 2.0))
+    expected_df.iloc[36:40, 0] = np.NaN
+    assert np.array_equal(computed_df.values, expected_df.values, equal_nan=True)

--- a/tests/test_prioritized_scheduler.py
+++ b/tests/test_prioritized_scheduler.py
@@ -28,40 +28,84 @@ def execute_before_and_after_one_test():
     df = pd.DataFrame(np.ones((m, n)))
 
     forms.config(
-        cores=4, scheduler="frrftwophase", enable_logical_rewriting=False, enable_physical_opt=True
+        cores=4, scheduler="prioritized", enable_logical_rewriting=False, enable_physical_opt=True
     )
     yield
 
 
-def test_compute_2_phase_sum_fr():
+def test_compute_ff_2_phase():
+    global df
+    computed_df = forms.compute_formula(df, "=SUM(MAX(A$1:B$2), COUNT(A$1:A1))")
+    expected_df = pd.DataFrame(np.arange(2, 102, 1))
+    assert np.array_equal(computed_df.values, expected_df.values)
+
+
+def test_compute_only_ff():
+    global df
+    computed_df = forms.compute_formula(df, "=SUM(A$2:B$3)")
+    expected_df = pd.DataFrame(np.full(100, 4))
+    assert np.array_equal(computed_df.values, expected_df.values)
+
+
+def test_compute_multiple_ff():
+    global df
+    computed_df = forms.compute_formula(df, "=SUM(A$2:B$3, B$1:B$100, SUM(C$10:C$19))")
+    expected_df = pd.DataFrame(np.full(100, 114))
+    assert np.array_equal(computed_df.values, expected_df.values)
+
+
+def test_compute_multiple_2_phase():
+    global df
+    computed_df = forms.compute_formula(df, "=MAX(SUM(A$2:B3), SUM(A$1:A1))")
+    expected_df = pd.DataFrame(np.arange(4, 200, 2))
+    assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values)
+
+
+def test_compute_multiple_ff_multiple_2_phase():
+    global df
+    computed_df = forms.compute_formula(
+        df, "=SUM(A$2:B3) + SUM(C$10:C$19) + MAX(SUM(A$2:B3), SUM(A$1:A1)) "
+    )
+    expected_df = pd.DataFrame(np.arange(18, 407, 4))
+    assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values)
+
+
+def test_compute_only_simple():
+    global df
+    computed_df = forms.compute_formula(df, "=SUM(A2:B3) + A1")
+    expected_df = pd.DataFrame(np.full(98, 5))
+    assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values)
+
+
+def test_compute_only_2_phase_sum_fr():
     global df
     computed_df = forms.compute_formula(df, "=SUM(A$2:B3)")
     expected_df = pd.DataFrame(np.arange(4, 200, 2))
     assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values)
 
 
-def test_compute_2_phase_sum_rf():
+def test_compute_only_2_phase_sum_rf():
     global df
     computed_df = forms.compute_formula(df, "=SUM(A2:B$99)")
     expected_df = pd.DataFrame(np.arange(196, 2, -2))
     assert np.array_equal(computed_df.iloc[0:97].values, expected_df.values)
 
 
-def test_compute_2_phase_count_fr():
+def test_compute_only_2_phase_count_fr():
     global df
     computed_df = forms.compute_formula(df, "=COUNT(A$1:B3)")
     expected_df = pd.DataFrame(np.arange(6, 202, 2))
     assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values)
 
 
-def test_compute_2_phase_count_rf():
+def test_compute_only_2_phase_count_rf():
     global df
     computed_df = forms.compute_formula(df, "=COUNT(A1:A$100)")
     expected_df = pd.DataFrame(np.arange(100, 0, -1))
     assert np.array_equal(computed_df.values, expected_df.values)
 
 
-def test_compute_2_phase_max_fr():
+def test_compute_only_2_phase_max_fr():
     global df
     computed_df = forms.compute_formula(df, "=MAX(A$1:B3)")
     expected_df = pd.DataFrame(np.full(100, 1))
@@ -69,14 +113,14 @@ def test_compute_2_phase_max_fr():
     assert np.array_equal(computed_df.values, expected_df.values, equal_nan=True)
 
 
-def test_compute_2_phase_min_rf():
+def test_compute_only_2_phase_min_rf():
     global df
     computed_df = forms.compute_formula(df, "=MIN(A1:A$100)")
     expected_df = pd.DataFrame(np.full(100, 1))
     assert np.array_equal(computed_df.values, expected_df.values)
 
 
-def test_compute_2_phase_avg_rf():
+def test_compute_only_2_phase_avg_rf():
     global df
     computed_df = forms.compute_formula(df, "=AVERAGE(A1:A$100)")
     expected_df = pd.DataFrame(np.full(100, 1))


### PR DESCRIPTION
## Changes

**Major**: Provide prioritized scheduler. 

Now the new scheduler contains 4 phases: 
1. `FF`, which will find all ff subtrees and execute each ff subtree on a single core. They will be computed in parallel.
2. `RFFRPhaseOne`, which will find all phase-one subtrees and execute each subtree across all cores. They will be computed one at a time.
3. `RFFRPhaseTwo`. Same as above. The only difference is to find phase-two subtrees.
4. `Simple`, which is the naive solution applied in `SimpleScheduler`. We will compute the whole execution tree across all cores.

The four phases are executed in a pipeline manner. If one phase cannot find a subtree to execute, it will be skipped.

**Minors**:
- Modify `nan` value semantics. If the window size is not large enough, it will say `nan` instead of computing the remaining cells.
- Modify `RefType.FF` execution. We executed `RefType.FF` by filling a whole column with the same value before. Now, it is changed to one single value, in other words, it will output a one-cell dataframe for the FF-type subtree.

## Example Output

Expected usecase of the new scheduler can be found in `tests/test_prioritized_scheduler.py`.
