### PR TITLE
FEAT: add median and sumif for pandas executor

### DIFF
--- a/forms/executor/dfexecutor/basicfuncexecutor.py
+++ b/forms/executor/dfexecutor/basicfuncexecutor.py
@@ -85,6 +85,48 @@ def average_df_executor(physical_subtree: FunctionExecutionNode) -> DFTable:
     )
 
 
+def median_df_executor(physical_subtree: FunctionExecutionNode) -> DFTable:
+    assert len(physical_subtree.children) == 1
+    child = physical_subtree.children[0]
+    result = None
+    if physical_subtree.out_ref_type == RefType.FF:
+        # all children must be either FF-type RefNode or LiteralNode
+        df = child.table.get_table_content()
+        start_row, start_column, end_row, end_column = get_reference_indices(child)
+        result = np.median(df.iloc[start_row:end_row, start_column:end_column].values.flatten())
+        # construct a one-cell dataframe table
+        return construct_df_table([result])
+    else:
+        ref = child.ref
+        df = child.table.get_table_content()
+        out_ref_type = child.out_ref_type
+        start_idx = child.exec_context.start_formula_idx
+        end_idx = child.exec_context.end_formula_idx
+        n_formula = end_idx - start_idx
+        axis = child.exec_context.axis
+        start_row, start_column, end_row, end_column = get_reference_indices(child)
+        df = df.iloc[start_row:end_row, start_column:end_column]
+        # TODO: add support for axis_along_column
+        if axis == axis_along_row:
+            window_size = ref.last_row - ref.row + 1
+            step = df.shape[1]
+            if out_ref_type == RefType.RR:
+                new_df = pd.concat([pd.Series([np.NaN]), df.stack()])
+                window_size = window_size * step
+                result = new_df.rolling(window_size, step=step).median().dropna()
+            elif out_ref_type == RefType.FR:
+                window_size = (window_size + start_idx) * step
+                result = df.stack().expanding(window_size).median().dropna()[::step]
+            elif out_ref_type == RefType.RF:
+                window_size = (window_size - end_idx + 1) * step
+                result = (
+                    df.stack().iloc[::-1].expanding(window_size).median().dropna()[::step].iloc[::-1]
+                )
+            result.index = range(result.index.size)
+            result = fill_in_nan(result, n_formula)
+            return construct_df_table(result)
+
+
 def plus_df_executor(physical_subtree: FunctionExecutionNode) -> DFTable:
     values = get_arithmetic_function_values(physical_subtree)
     return construct_df_table(values[0] + values[1])
@@ -268,6 +310,7 @@ function_to_executor_dict = {
     Function.MIN: min_df_executor,
     Function.COUNT: count_df_executor,
     Function.AVG: average_df_executor,
+    Function.MEDIAN: median_df_executor,
     Function.SUM: sum_df_executor,
     Function.PLUS: plus_df_executor,
     Function.MINUS: minus_df_executor,

--- a/forms/utils/functions.py
+++ b/forms/utils/functions.py
@@ -85,6 +85,7 @@ pandas_supported_functions = {
     Function.COUNT,
     Function.AVG,
     Function.MEDIAN,
+    Function.SUMIF,
     Function.ABS,
     Function.ACOS,
     Function.ACOSH,

--- a/forms/utils/functions.py
+++ b/forms/utils/functions.py
@@ -25,6 +25,7 @@ class Function(Enum):
     AVG = "average"
     MIN = "min"
     MAX = "max"
+    MEDIAN = "median"
     PLUS = "+"
     MINUS = "-"
     MULTIPLY = "*"
@@ -83,6 +84,7 @@ pandas_supported_functions = {
     Function.MAX,
     Function.COUNT,
     Function.AVG,
+    Function.MEDIAN,
     Function.ABS,
     Function.ACOS,
     Function.ACOSH,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.16.5
-pandas
+pandas>=1.5.0
 black==22.3.0
 xlsxwriter
 jpype1

--- a/tests/test_compute_median.py
+++ b/tests/test_compute_median.py
@@ -1,0 +1,63 @@
+#  Copyright 2022-2023 The FormS Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+import pandas as pd
+import numpy as np
+
+import forms
+
+df = None
+
+
+@pytest.fixture(autouse=True)
+def execute_before_and_after_one_test():
+    m = 100
+    n = 5
+    global df
+    df = pd.DataFrame(np.array(np.arange(0, m * n).reshape(m, n)))
+
+    forms.config(
+        cores=4,
+        scheduler="simple",
+    )
+    yield
+
+
+def test_compute_median_rr():
+    global df
+    computed_df = forms.compute_formula(df, "=MEDIAN(A1:C3)")
+    expected_df = pd.DataFrame(np.arange(6, 492, 5))
+    assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values, equal_nan=True)
+
+
+def test_compute_median_ff():
+    global df
+    computed_df = forms.compute_formula(df, "=MEDIAN(A$1:C$3)")
+    expected_df = pd.DataFrame(np.full(100, 6))
+    assert np.array_equal(computed_df.values, expected_df.values)
+
+
+def test_compute_median_rf():
+    global df
+    computed_df = forms.compute_formula(df, "=MEDIAN(A1:C$100)")
+    expected_df = pd.DataFrame(np.arange(248.5, 497, 2.5))
+    assert np.array_equal(computed_df.values, expected_df.values)
+
+
+def test_compute_median_fr():
+    global df
+    computed_df = forms.compute_formula(df, "=MEDIAN(A$1:C3)")
+    expected_df = pd.DataFrame(np.arange(6, 249, 2.5))
+    assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values, equal_nan=True)

--- a/tests/test_compute_median_sumif.py
+++ b/tests/test_compute_median_sumif.py
@@ -61,3 +61,33 @@ def test_compute_median_fr():
     computed_df = forms.compute_formula(df, "=MEDIAN(A$1:C3)")
     expected_df = pd.DataFrame(np.arange(6, 249, 2.5))
     assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values, equal_nan=True)
+
+
+def test_compute_sumif_rr():
+    global df
+    computed_df = forms.compute_formula(df, '=SUMIF(A1:C3, ">50")')
+    expected_df = pd.concat(
+        [pd.DataFrame([0] * 8 + [103, 271, 454]), pd.DataFrame(np.arange(549, 4420, 45))]
+    )
+    assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values, equal_nan=True)
+
+
+def test_compute_sumif_ff():
+    global df
+    computed_df = forms.compute_formula(df, '=SUMIF(A$10:C$12, ">50")')
+    expected_df = pd.DataFrame(np.full(100, 271))
+    assert np.array_equal(computed_df.values, expected_df.values)
+
+
+def test_compute_sumif_rf():
+    df = pd.DataFrame(np.ones((100, 5)))
+    computed_df = forms.compute_formula(df, '=SUMIF(A1:C$100, "<=1")')
+    expected_df = pd.DataFrame(np.arange(300, 0, -3))
+    assert np.array_equal(computed_df.values, expected_df.values)
+
+
+def test_compute_sumif_fr():
+    df = pd.DataFrame(np.ones((100, 5)))
+    computed_df = forms.compute_formula(df, '=SUMIF(A$1:C3, ">=1")')
+    expected_df = pd.DataFrame(np.arange(9, 303, 3))
+    assert np.array_equal(computed_df.iloc[0:98].values, expected_df.values)


### PR DESCRIPTION
## Overview

Support MEDIAN and SUMIF functions within pandas executor.

## Changes

- `MEDIAN` function follows basic semantics. However, we only support single-range parameter ie. `MEDIAN(A1:B3)` is supported whereas `MEDIAN(A1:B3, A$2)` is not.
- `SUMIF` function supports limited semantics. Specifically, a function like `=SUMIF(A2:A5,">10")` where the first parameter is a range and the second is an operator followed by a value.

## Example Output

Expected use cases can be found in `test/test_compute_median_sumif.py`
